### PR TITLE
Adding help to calendar event page

### DIFF
--- a/includes/common/admin.php
+++ b/includes/common/admin.php
@@ -43,6 +43,8 @@ function wp_event_calendar_add_submenus() {
 		add_action( "admin_head-{$hook}", 'wp_event_calendar_admin_submenu_highlight'  );
 		add_action( "admin_head-{$hook}", 'wp_event_calendar_admin_add_screen_options' );
 		add_action( "admin_head-{$hook}", 'wp_event_calendar_admin_pointer_buttons'    );
+		add_action( "admin_head-{$hook}", 'wp_event_calendar_admin_add_help_tabs' 	   ); // Adding help tab to calendar page
+
 	}
 }
 


### PR DESCRIPTION
I saw the help section useful but it wasn't on the calendar page. I think it would be useful for users to have on the calendar page as well.

![screen shot 2016-04-30 at 7 00 45 pm](https://cloud.githubusercontent.com/assets/570018/14939286/faace13e-0f05-11e6-8a8e-adf9d1f82e25.png)
