### PR TITLE
Correct end cell calculation on all day events

### DIFF
--- a/wp-event-calendar/includes/common/list-table-week.php
+++ b/wp-event-calendar/includes/common/list-table-week.php
@@ -144,7 +144,7 @@ class WP_Event_Calendar_Week_Table extends WP_Event_Calendar_List_Table {
 			$interval = 1;
 			$offset   = - ceil( ( $this->week_start - $this->item_start ) / DAY_IN_SECONDS );
 			$cell     = $offset;
-			$end_cell = ( $end_day * $start_day ) + $offset;
+			$end_cell = ( $end_day - $start_day ) + $offset;
 
 		// Regular single-day events
 		} else {


### PR DESCRIPTION
Previously, an all day event on Friday the 19th would end up with a cell position of 361 + 5 = 366 making a single day event fill out the rest of the week.

Props to bpardee in the support forums https://wordpress.org/support/topic/all-day-event-on-weekly-calendar-displays-incorrectly/